### PR TITLE
VZ-9148: BFS of kubectl for 1.25.7 version

### DIFF
--- a/BUILD_FROM_SOURCE_README.md
+++ b/BUILD_FROM_SOURCE_README.md
@@ -7,15 +7,15 @@ Create Environment Variables
 ```
 export DOCKER_REPO=<Docker Repository>
 export DOCKER_NAMESPACE=<Docker Namespace>
-export DOCKER_TAG=v1.20.2-BFS
+export DOCKER_TAG=v1.25.7-BFS
 ```
 
 Build and Push Images
 
 ```
 # Build and push rancher-webhook
-docker build --build-arg ARCH=amd64 --tag rancher/kubectl:v1.20.2 .
+docker build --build-arg ARCH=amd64 --tag rancher/kubectl:v1.25.7 .
 
-docker tag rancher/kubectl:v1.20.2 ${DOCKER_REPO}/${DOCKER_NAMESPACE}/kubectl:${DOCKER_TAG}
+docker tag rancher/kubectl:v1.25.7 ${DOCKER_REPO}/${DOCKER_NAMESPACE}/kubectl:${DOCKER_TAG}
 docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/kubectl:${DOCKER_TAG}
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-# Copyright (C) 2022, Oracle and/or its affiliates.
+# Copyright (C) 2023, Oracle and/or its affiliates.
 
-FROM ghcr.io/oracle/oraclelinux:7-slim AS builder
+FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
 ARG ARCH
-ARG KUBERNETES_RELEASE=v1.20.2
+ARG KUBERNETES_RELEASE=v1.25.7
+
+RUN pwd
+# copy olcne repos needed to install kubectl, istioctl
+COPY repos/*.repo /etc/yum.repos.d/
+
 WORKDIR /bin
-RUN set -x \
- && curl -fsSLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_RELEASE}/bin/linux/${ARCH}/kubectl \
- && chmod +x kubectl
+
+RUN yum update -y \
+    && yum install -y kubectl-1.25.7-1.el7 \
+    && yum clean all \
+    && chmod +x kubectl
 
 FROM scratch
-COPY --from=builder /bin/kubectl /bin/kubectl
+COPY --from=build_base /bin/kubectl /bin/kubectl
 ENTRYPOINT ["/bin/kubectl"]
 CMD ["help"]

--- a/repos/ol7-developer-olcne.repo
+++ b/repos/ol7-developer-olcne.repo
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+[ol7_developer-olcne]
+name=Oracle Linux 7 OLCNE Developer
+baseurl=http://yum.oracle.com/repo/OracleLinux/OL7/developer/olcne/x86_64
+gpgcheck=0
+enabled=1

--- a/repos/ol7-olcne16.repo
+++ b/repos/ol7-olcne16.repo
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+[ol7-olcne]
+name=Oracle Linux 7 OLCNE 1.6
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/olcne16/x86_64
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
This PR builds kubectl from source for 1.25.7 version. 